### PR TITLE
Update bitmex.py (Asyncio.Lock())

### DIFF
--- a/bitmex/bitmex.py
+++ b/bitmex/bitmex.py
@@ -164,7 +164,5 @@ if __name__ == "__main__":
 
         print("DONE!")
 
-    # Run the 'main' function in an asyncio event loop
-    loop = asyncio.get_event_loop()
-    loop.create_task(main())
-    loop.run_forever()
+    # Run the 'main' function as an asynchronous coroutine
+    asyncio.run(main())

--- a/bitmex/bitmex.py
+++ b/bitmex/bitmex.py
@@ -26,7 +26,7 @@ class BitMex:
         self.__running_task = None
         self.__subscriptions = {}
         self.__data = {}
-        self.__lock = asyncio.Lock(loop=loop)
+        self.__lock = asyncio.Lock()
 
     async def __connect(self):
         # Connect to the websocket API and start the __run coroutine


### PR DESCRIPTION
loop parameter is removed as it's incompatible with recent Python versions. loop is applied by default to Asyncio.Lock()

Using the loop parameter will cause Python import module error as it's removed from Asyncio.Lock function as of 3.10 as the error will suggest making the example unusable out of the box.

The full code should run fine after this update.